### PR TITLE
rtmutex: Fix CVE-2026-43499 (GhostLock) in remove_waiter()

### DIFF
--- a/kernel/locking/rtmutex.c
+++ b/kernel/locking/rtmutex.c
@@ -1062,20 +1062,23 @@ static void mark_wakeup_next_waiter(struct wake_q_head *wake_q,
  *
  * Must be called with lock->wait_lock held and interrupts disabled. I must
  * have just failed to try_to_take_rt_mutex().
+ *
+ * When invoked from rt_mutex_start_proxy_lock() waiter::task != current !
  */
 static void remove_waiter(struct rt_mutex *lock,
 			  struct rt_mutex_waiter *waiter)
 {
 	bool is_top_waiter = (waiter == rt_mutex_top_waiter(lock));
 	struct task_struct *owner = rt_mutex_owner(lock);
+	struct task_struct *waiter_task = waiter->task;
 	struct rt_mutex *next_lock;
 
 	lockdep_assert_held(&lock->wait_lock);
 
-	raw_spin_lock(&current->pi_lock);
+	raw_spin_lock(&waiter_task->pi_lock);
 	rt_mutex_dequeue(lock, waiter);
-	current->pi_blocked_on = NULL;
-	raw_spin_unlock(&current->pi_lock);
+	waiter_task->pi_blocked_on = NULL;
+	raw_spin_unlock(&waiter_task->pi_lock);
 
 	/*
 	 * Only update priority if the waiter was the highest priority
@@ -1111,7 +1114,7 @@ static void remove_waiter(struct rt_mutex *lock,
 	raw_spin_unlock_irq(&lock->wait_lock);
 
 	rt_mutex_adjust_prio_chain(owner, RT_MUTEX_MIN_CHAINWALK, lock,
-				   next_lock, NULL, current);
+				   next_lock, NULL, waiter_task);
 
 	raw_spin_lock_irq(&lock->wait_lock);
 }


### PR DESCRIPTION
remove_waiter() is used by the slowlock paths, but also from rt_mutex_start_proxy_lock() for the proxy-lock rollback invoked from futex_requeue().

In the latter case waiter::task is not current, but remove_waiter() incorrectly operates on current. This causes three problems:

  1. The rbtree dequeue happens without holding waiter::task::pi_lock

  2. The waiter task's pi_blocked_on state is not cleared, which leaves a dangling pointer and is a UAF hazard

  3. rt_mutex_adjust_prio_chain() operates on the wrong top-priority waiter task

Use waiter::task instead of current in all relevant operations in remove_waiter() to fix these problems.

[ tglx: Fixed up rt_mutex_adjust_prio_chain(), added comments and
  massaged changelog ]

Adapted for 4.19: upstream commit 3bfdc63936dd uses scoped_guard() which is not available in this kernel version. The equivalent raw_spin_lock/unlock pattern is used instead.

CVE-2026-43499
Fixes: 8161239a8bcce9ad6b537c04a1fa3b5c68bae693 ("rtmutex: Simplify PI algorithm and make highest prio task get lock")