### PR TITLE
build: add always-on DroidSpaces support with CI integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,15 +36,10 @@ on:
           - aosp
           - miui
           - both
-      droidspaces:
-        description: 'Enable DroidSpaces support'
-        required: true
-        type: boolean
-        default: false
 
 jobs:
   build-kernel:
-    name: Build ${{ github.event.inputs.device }} | KSU:${{ github.event.inputs.ksu }} | OS:${{ github.event.inputs.target_os }} | DS:${{ github.event.inputs.droidspaces }}
+    name: Build ${{ github.event.inputs.device }} | KSU:${{ github.event.inputs.ksu }} | OS:${{ github.event.inputs.target_os }}
     runs-on: ubuntu-latest
     
     steps:
@@ -90,10 +85,6 @@ jobs:
         
         if [ "${{ github.event.inputs.target_os }}" != "both" ]; then
           ARGS="$ARGS ${{ github.event.inputs.target_os }}"
-        fi
-
-        if [ "${{ github.event.inputs.droidspaces }}" == "true" ]; then
-          ARGS="$ARGS droidspaces"
         fi
         
         echo "Executing command: ./build_kernel.sh $ARGS"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,15 @@ on:
           - aosp
           - miui
           - both
+      droidspaces:
+        description: 'Enable DroidSpaces support'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   build-kernel:
-    name: Build ${{ github.event.inputs.device }} | KSU:${{ github.event.inputs.ksu }} | OS:${{ github.event.inputs.target_os }}
+    name: Build ${{ github.event.inputs.device }} | KSU:${{ github.event.inputs.ksu }} | OS:${{ github.event.inputs.target_os }} | DS:${{ github.event.inputs.droidspaces }}
     runs-on: ubuntu-latest
     
     steps:
@@ -85,6 +90,10 @@ jobs:
         
         if [ "${{ github.event.inputs.target_os }}" != "both" ]; then
           ARGS="$ARGS ${{ github.event.inputs.target_os }}"
+        fi
+
+        if [ "${{ github.event.inputs.droidspaces }}" == "true" ]; then
+          ARGS="$ARGS droidspaces"
         fi
         
         echo "Executing command: ./build_kernel.sh $ARGS"

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -79,8 +79,6 @@ jobs:
           if [ "${{ matrix.ksu }}" = "true" ]; then
             ARGS="$ARGS ksu"
           fi
-          # Always enable DroidSpaces regardless of any condition
-          ARGS="$ARGS droidspaces"
           
           echo "Executing command: ./build_kernel.sh $ARGS"
           ./build_kernel.sh $ARGS
@@ -135,5 +133,5 @@ jobs:
             - **AOSP**: 适用于 LineageOS 等类原生 AOSP ROM。
             - **ReSukiSU-SuSFS**: 集成 ReSukiSU 与 SuSFS。
             - **NoKernelSU**: 原版纯净内核，支持自行使用 Magisk 或 APatch 刷入。
-            - **DroidSpaces**: 所有构建均已启用 DroidSpaces，文件名含该标识。如不需要，请使用 `Build Kernel` 单设备工作流构建（DroidSpaces 选项默认关闭），或 Fork 后自行修改 workflow。
+            - **DroidSpaces**: 所有构建均已启用 DroidSpaces，文件名含该标识。
           files: all_kernels/*.zip

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: boolean
         default: true
+      droidspaces:
+        description: 'Enable DroidSpaces for all builds'
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -79,6 +84,9 @@ jobs:
           if [ "${{ matrix.ksu }}" = "true" ]; then
             ARGS="$ARGS ksu"
           fi
+          if [ "${{ github.event.inputs.droidspaces }}" = "true" ]; then
+            ARGS="$ARGS droidspaces"
+          fi
           
           echo "Executing command: ./build_kernel.sh $ARGS"
           ./build_kernel.sh $ARGS
@@ -133,4 +141,5 @@ jobs:
             - **AOSP**: 适用于 LineageOS 等类原生 AOSP ROM。
             - **ReSukiSU-SuSFS**: 集成 ReSukiSU 与 SuSFS。
             - **NoKernelSU**: 原版纯净内核，支持自行使用 Magisk 或 APatch 刷入。
+            - **DroidSpaces**: 启用 DroidSpaces 支持，文件名含该标识。
           files: all_kernels/*.zip

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -8,11 +8,6 @@ on:
         required: true
         type: boolean
         default: true
-      droidspaces:
-        description: 'Enable DroidSpaces for all builds'
-        required: true
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -84,9 +79,8 @@ jobs:
           if [ "${{ matrix.ksu }}" = "true" ]; then
             ARGS="$ARGS ksu"
           fi
-          if [ "${{ github.event.inputs.droidspaces }}" = "true" ]; then
-            ARGS="$ARGS droidspaces"
-          fi
+          # Always enable DroidSpaces regardless of any condition
+          ARGS="$ARGS droidspaces"
           
           echo "Executing command: ./build_kernel.sh $ARGS"
           ./build_kernel.sh $ARGS
@@ -141,5 +135,5 @@ jobs:
             - **AOSP**: 适用于 LineageOS 等类原生 AOSP ROM。
             - **ReSukiSU-SuSFS**: 集成 ReSukiSU 与 SuSFS。
             - **NoKernelSU**: 原版纯净内核，支持自行使用 Magisk 或 APatch 刷入。
-            - **DroidSpaces**: 启用 DroidSpaces 支持，文件名含该标识。
+            - **DroidSpaces**: 所有构建均已启用 DroidSpaces，文件名含该标识。如不需要请自行 Fork 仓库构建。
           files: all_kernels/*.zip

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -135,5 +135,5 @@ jobs:
             - **AOSP**: 适用于 LineageOS 等类原生 AOSP ROM。
             - **ReSukiSU-SuSFS**: 集成 ReSukiSU 与 SuSFS。
             - **NoKernelSU**: 原版纯净内核，支持自行使用 Magisk 或 APatch 刷入。
-            - **DroidSpaces**: 所有构建均已启用 DroidSpaces，文件名含该标识。如不需要请自行 Fork 仓库构建。
+            - **DroidSpaces**: 所有构建均已启用 DroidSpaces，文件名含该标识。如不需要，请使用 `Build Kernel` 单设备工作流构建（DroidSpaces 选项默认关闭），或 Fork 后自行修改 workflow。
           files: all_kernels/*.zip

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Join ApartTUSITU's QQ Group: [700675046](https://qm.qq.com/q/Md7nXA3Toa)。
 3. 如果你要为所有支持的设备编译内核，找到 `Build All Devices Kernel (Matrix Parallel + Release)`，点击 `Run workflow`  
 4. 如果你要为单个设备编译内核，找到 `Build Kernel`， 点击 `Run workflow` 并选择必要内容  
 
-**注意:** `Build All Devices Kernel (Matrix Parallel + Release)` 的所有构建均已启用 DroidSpaces。如果你不想要 DroidSpaces，请改用 `Build Kernel` 单设备工作流构建（其 DroidSpaces 选项默认关闭），或 Fork 后自行修改 workflow。  
+**注意:** 所有构建（包括手动构建）均已默认集成 DroidSpaces，文件名含 `_DroidSpaces` 标识。如果你不想要 DroidSpaces，请 Fork 后自行修改 `build_kernel.sh`。  
 
 **English:**  
 1. Fork this repo (don’t forget to leave a Star~)  
@@ -107,7 +107,7 @@ Join ApartTUSITU's QQ Group: [700675046](https://qm.qq.com/q/Md7nXA3Toa)。
 3. If you want to compile the kernel for all supported devices, find `Build All Devices Kernel (Matrix Parallel + Release)` and click `Run workflow`  
 4. If you want to compile the kernel for a single device, find `Build Kernel`, click `Run workflow`, and select the necessary options  
 
-**Note:** All builds from `Build All Devices Kernel (Matrix Parallel + Release)` come with DroidSpaces enabled. If you don't want DroidSpaces, use the `Build Kernel` single-device workflow instead (its DroidSpaces option is off by default), or fork this repository and adjust the workflow yourself.  
+**Note:** All builds (including manual ones) come with DroidSpaces enabled by default, and the ZIP filename carries the `_DroidSpaces` tag. If you don't want DroidSpaces, fork this repository and adjust `build_kernel.sh` yourself.  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,15 @@ Join ApartTUSITU's QQ Group: [700675046](https://qm.qq.com/q/Md7nXA3Toa)。
 3. 如果你要为所有支持的设备编译内核，找到 `Build All Devices Kernel (Matrix Parallel + Release)`，点击 `Run workflow`  
 4. 如果你要为单个设备编译内核，找到 `Build Kernel`， 点击 `Run workflow` 并选择必要内容  
 
+**注意:** `Build All Devices Kernel (Matrix Parallel + Release)` 的所有构建均已启用 DroidSpaces。如果你不想要 DroidSpaces，请自行 Fork 仓库去 Actions 构建。  
+
 **English:**  
 1. Fork this repo (don’t forget to leave a Star~)  
 2. Go to **Actions**  
 3. If you want to compile the kernel for all supported devices, find `Build All Devices Kernel (Matrix Parallel + Release)` and click `Run workflow`  
 4. If you want to compile the kernel for a single device, find `Build Kernel`, click `Run workflow`, and select the necessary options  
+
+**Note:** All builds from `Build All Devices Kernel (Matrix Parallel + Release)` come with DroidSpaces enabled. If you don't want DroidSpaces, please fork this repository and build it yourself via Actions.  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Join ApartTUSITU's QQ Group: [700675046](https://qm.qq.com/q/Md7nXA3Toa)。
 3. 如果你要为所有支持的设备编译内核，找到 `Build All Devices Kernel (Matrix Parallel + Release)`，点击 `Run workflow`  
 4. 如果你要为单个设备编译内核，找到 `Build Kernel`， 点击 `Run workflow` 并选择必要内容  
 
-**注意:** `Build All Devices Kernel (Matrix Parallel + Release)` 的所有构建均已启用 DroidSpaces。如果你不想要 DroidSpaces，请自行 Fork 仓库去 Actions 构建。  
+**注意:** `Build All Devices Kernel (Matrix Parallel + Release)` 的所有构建均已启用 DroidSpaces。如果你不想要 DroidSpaces，请改用 `Build Kernel` 单设备工作流构建（其 DroidSpaces 选项默认关闭），或 Fork 后自行修改 workflow。  
 
 **English:**  
 1. Fork this repo (don’t forget to leave a Star~)  
@@ -107,7 +107,7 @@ Join ApartTUSITU's QQ Group: [700675046](https://qm.qq.com/q/Md7nXA3Toa)。
 3. If you want to compile the kernel for all supported devices, find `Build All Devices Kernel (Matrix Parallel + Release)` and click `Run workflow`  
 4. If you want to compile the kernel for a single device, find `Build Kernel`, click `Run workflow`, and select the necessary options  
 
-**Note:** All builds from `Build All Devices Kernel (Matrix Parallel + Release)` come with DroidSpaces enabled. If you don't want DroidSpaces, please fork this repository and build it yourself via Actions.  
+**Note:** All builds from `Build All Devices Kernel (Matrix Parallel + Release)` come with DroidSpaces enabled. If you don't want DroidSpaces, use the `Build Kernel` single-device workflow instead (its DroidSpaces option is off by default), or fork this repository and adjust the workflow yourself.  
 
 ---
 

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -8,11 +8,12 @@ set -e
 # ==========================================
 if [ -z "$1" ]; then
     echo "[!] Error: No device specified."
-    echo "Usage: $0 <device_name> [ksu] [miui|aosp]"
+    echo "Usage: $0 <device_name> [ksu] [miui|aosp] [droidspaces]"
     echo "Example: $0 lmi"
     echo "         $0 lmi ksu"
     echo "         $0 lmi ksu miui"
     echo "         $0 lmi aosp"
+    echo "         $0 lmi ksu miui droidspaces (DroidSpaces support)"
     exit 1
 fi
 
@@ -27,6 +28,7 @@ if [ ! -f "$DEFCONFIG_PATH" ]; then
 fi
 
 ENABLE_KSU=0
+ENABLE_DROIDSPACES=0
 TARGET_OS="both"
 
 shift
@@ -36,6 +38,7 @@ for arg in "$@"; do
         ksu) ENABLE_KSU=1 ;;
         miui) TARGET_OS="miui" ;;
         aosp) TARGET_OS="aosp" ;;
+        droidspaces) ENABLE_DROIDSPACES=1 ;;
     esac
 done
 
@@ -93,6 +96,147 @@ echo "[*] Patching security/Kconfig for baseband_guard..."
 sed -i '/^config LSM$/,/^help$/{ /^[[:space:]]*default/ { /baseband_guard/! s/selinux/selinux,baseband_guard/ } }' security/Kconfig
 echo "[+] Baseband-guard setup finished."
 echo "==========================================="
+
+# ==========================================
+# DroidSpaces Setup
+# ==========================================
+if [ "$ENABLE_DROIDSPACES" -eq 1 ]; then
+    echo "==========================================="
+    echo " [*] Initializing DroidSpaces Setup"
+    echo "==========================================="
+
+    DS_TMP_DIR=$(mktemp -d)
+    DS_BASE_URL="https://raw.githubusercontent.com/ravindu644/Droidspaces-OSS/main/Documentation/resources/kernel-patches/non-GKI"
+
+    echo "[*] Downloading DroidSpaces kernel patches..."
+    wget -q -O "$DS_TMP_DIR/01_fix_xt_qtaguid.patch" \
+        "$DS_BASE_URL/01.fix_kernel_panic_in_xt_qtaguid.patch"
+    wget -q -O "$DS_TMP_DIR/02_fix_cgroup_prefix.patch" \
+        "$DS_BASE_URL/02.fix_restore%20cgroup%20file%20prefix%20handling%20.patch"
+
+    cd "$KERNEL_DIR"
+
+    # Dry-run first: skip cleanly when already applied or not applicable
+    apply_droidspaces_patch() {
+        local patch_file=$1
+        if patch -p1 --forward --dry-run < "$patch_file" > /dev/null 2>&1; then
+            patch -p1 --forward < "$patch_file"
+            echo "[+] Patch applied: $(basename "$patch_file")"
+        else
+            echo "[-] Patch skipped (already applied or not applicable): $(basename "$patch_file")"
+        fi
+    }
+
+    # 1) xt_qtaguid panic fix (auto-skipped if net/netfilter/xt_qtaguid.c does not exist)
+    apply_droidspaces_patch "$DS_TMP_DIR/01_fix_xt_qtaguid.patch"
+
+    # 2) cgroup file prefix handling fix (required by DroidSpaces)
+    apply_droidspaces_patch "$DS_TMP_DIR/02_fix_cgroup_prefix.patch"
+
+    # Generate DroidSpaces config fragment for later merging into out/.config
+    DS_CONFIG_FRAG="$DS_TMP_DIR/droidspaces.config"
+    cat > "$DS_CONFIG_FRAG" <<'EOF'
+# Kernel configurations for full DroidSpaces support
+# Copyright (C) 2026 ravindu644 <droidcasts@protonmail.com>
+
+# IPC mechanisms
+CONFIG_SYSCTL=y
+CONFIG_SYSVIPC=y
+CONFIG_POSIX_MQUEUE=y
+
+# Core namespace support
+CONFIG_NAMESPACES=y
+CONFIG_PID_NS=y
+CONFIG_UTS_NS=y
+CONFIG_IPC_NS=y
+
+# Seccomp support
+CONFIG_SECCOMP=y
+CONFIG_SECCOMP_FILTER=y
+
+# Control groups support
+CONFIG_CGROUPS=y
+CONFIG_CGROUP_DEVICE=y
+CONFIG_CGROUP_PIDS=y
+CONFIG_MEMCG=y
+CONFIG_CGROUP_SCHED=y
+CONFIG_FAIR_GROUP_SCHED=y
+CONFIG_CGROUP_FREEZER=y
+CONFIG_CGROUP_NET_PRIO=y
+
+# Device filesystem support
+CONFIG_DEVTMPFS=y
+
+# Overlay filesystem support (required for volatile mode)
+CONFIG_OVERLAY_FS=y
+
+# Enable xattr, posix acl support on tmpfs
+CONFIG_TMPFS_POSIX_ACL=y
+CONFIG_TMPFS_XATTR=y
+
+# Firmware loading support
+CONFIG_FW_LOADER=y
+CONFIG_FW_LOADER_USER_HELPER=y
+CONFIG_FW_LOADER_COMPRESS=y
+
+# DroidSpaces Network Isolation Support - NAT/none modes
+CONFIG_NET_NS=y
+CONFIG_VETH=y
+CONFIG_BRIDGE=y
+CONFIG_NETFILTER=y
+CONFIG_BRIDGE_NETFILTER=y
+CONFIG_NETFILTER_ADVANCED=y
+CONFIG_NF_CONNTRACK=y
+CONFIG_IP_NF_IPTABLES=y
+CONFIG_IP_NF_FILTER=y
+CONFIG_NF_NAT=y
+CONFIG_NF_TABLES=y
+CONFIG_IP_NF_TARGET_MASQUERADE=y
+CONFIG_NETFILTER_XT_TARGET_MASQUERADE=y
+CONFIG_NETFILTER_XT_TARGET_TCPMSS=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NF_CONNTRACK_NETLINK=y
+CONFIG_NF_NAT_REDIRECT=y
+CONFIG_IP_ADVANCED_ROUTER=y
+CONFIG_IP_MULTIPLE_TABLES=y
+
+# legacy compat (ignored automatically on newer kernels)
+CONFIG_NF_CONNTRACK_IPV4=y
+CONFIG_NF_NAT_IPV4=y
+CONFIG_IP_NF_NAT=y
+
+# Disable this on older kernels to make internet work
+CONFIG_ANDROID_PARANOID_NETWORK=n
+
+# UFW & FAIL2BAN CORE
+CONFIG_NETFILTER_XT_MATCH_COMMENT=y
+CONFIG_NETFILTER_XT_MATCH_STATE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
+CONFIG_NETFILTER_XT_MATCH_HL=y
+CONFIG_NETFILTER_XT_TARGET_REJECT=y
+CONFIG_IP_NF_TARGET_REJECT=y
+CONFIG_NETFILTER_XT_TARGET_LOG=y
+CONFIG_IP_NF_TARGET_ULOG=y
+CONFIG_NETFILTER_XT_MATCH_RECENT=y
+CONFIG_NETFILTER_XT_MATCH_LIMIT=y
+CONFIG_NETFILTER_XT_MATCH_HASHLIMIT=y
+CONFIG_NETFILTER_XT_MATCH_OWNER=y
+CONFIG_NETFILTER_XT_MATCH_PKTTYPE=y
+CONFIG_NETFILTER_XT_MATCH_MARK=y
+CONFIG_NETFILTER_XT_TARGET_MARK=y
+CONFIG_IP_SET=y
+CONFIG_IP_SET_HASH_IP=y
+CONFIG_IP_SET_HASH_NET=y
+CONFIG_NETFILTER_XT_SET=y
+CONFIG_NETFILTER_NETLINK_QUEUE=y
+CONFIG_NETFILTER_NETLINK_LOG=y
+CONFIG_NETFILTER_XT_TARGET_NFLOG=y
+EOF
+
+    echo "[+] DroidSpaces setup finished."
+    echo "==========================================="
+fi
 
 # ==========================================
 # AnyKernel3 Setup
@@ -259,6 +403,12 @@ build_target() {
             -e REKERNEL_NETWORK
     fi
 
+    # 5. DroidSpaces configurations
+    if [ "$ENABLE_DROIDSPACES" -eq 1 ]; then
+        echo "[*] Merging DroidSpaces configurations..."
+        scripts/kconfig/merge_config.sh -O "${OUT_DIR}/" -m "${OUT_DIR}/.config" "${DS_CONFIG_FRAG}"
+    fi
+
     # We always need to re-evaluate dependencies because BBG is injected unconditionally
     echo "[*] Updating config (make olddefconfig)..."
     make "${MAKE_OPTS[@]}" olddefconfig
@@ -298,9 +448,13 @@ build_target() {
         if [ "$ENABLE_KSU" -eq 1 ]; then
             KSU_ZIP_STR="ReSukiSU-SuSFS"
         fi
+        local DS_ZIP_STR=""
+        if [ "$ENABLE_DROIDSPACES" -eq 1 ]; then
+            DS_ZIP_STR="_DroidSpaces"
+        fi
         local GIT_COMMIT_ID=$(git rev-parse --short=8 HEAD 2>/dev/null || echo "unknown")
         local OS_UPPER=$(echo "$OS_TYPE" | tr '[:lower:]' '[:upper:]')
-        local ZIP_FILENAME="APTKernel_${OS_UPPER}_${DEVICE_NAME}_${KSU_ZIP_STR}_$(date +'%Y%m%d_%H%M%S')_anykernel3_${GIT_COMMIT_ID}.zip"
+        local ZIP_FILENAME="APTKernel_${OS_UPPER}_${DEVICE_NAME}_${KSU_ZIP_STR}${DS_ZIP_STR}_$(date +'%Y%m%d_%H%M%S')_anykernel3_${GIT_COMMIT_ID}.zip"
         
         echo "[*] Zipping $ZIP_FILENAME ..."
         pushd anykernel > /dev/null
@@ -329,4 +483,10 @@ fi
 echo "==========================================="
 echo "[*] ccache stats:"
 ccache -s
+
+# Cleanup DroidSpaces temp directory
+if [ -n "$DS_TMP_DIR" ] && [ -d "$DS_TMP_DIR" ]; then
+    rm -rf "$DS_TMP_DIR"
+fi
+
 echo "[+] All requested builds completed!"

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -8,12 +8,11 @@ set -e
 # ==========================================
 if [ -z "$1" ]; then
     echo "[!] Error: No device specified."
-    echo "Usage: $0 <device_name> [ksu] [miui|aosp] [droidspaces]"
+    echo "Usage: $0 <device_name> [ksu] [miui|aosp]"
     echo "Example: $0 lmi"
     echo "         $0 lmi ksu"
     echo "         $0 lmi ksu miui"
     echo "         $0 lmi aosp"
-    echo "         $0 lmi ksu miui droidspaces (DroidSpaces support)"
     exit 1
 fi
 
@@ -28,7 +27,6 @@ if [ ! -f "$DEFCONFIG_PATH" ]; then
 fi
 
 ENABLE_KSU=0
-ENABLE_DROIDSPACES=0
 TARGET_OS="both"
 DS_TMP_DIR=""
 
@@ -39,7 +37,6 @@ for arg in "$@"; do
         ksu) ENABLE_KSU=1 ;;
         miui) TARGET_OS="miui" ;;
         aosp) TARGET_OS="aosp" ;;
-        droidspaces) ENABLE_DROIDSPACES=1 ;;
     esac
 done
 
@@ -109,63 +106,62 @@ echo "==========================================="
 # ==========================================
 # DroidSpaces Setup
 # ==========================================
-if [ "$ENABLE_DROIDSPACES" -eq 1 ]; then
-    echo "==========================================="
-    echo " [*] Initializing DroidSpaces Setup"
-    echo "==========================================="
+echo "==========================================="
+echo " [*] Initializing DroidSpaces Setup"
+echo "==========================================="
 
-    DS_TMP_DIR=$(mktemp -d)
-    DS_BASE_URL="https://raw.githubusercontent.com/ravindu644/Droidspaces-OSS/main/Documentation/resources/kernel-patches/non-GKI"
+DS_TMP_DIR=$(mktemp -d)
+DS_BASE_URL="https://raw.githubusercontent.com/ravindu644/Droidspaces-OSS/main/Documentation/resources/kernel-patches/non-GKI"
 
-    echo "[*] Downloading DroidSpaces kernel patches..."
-    wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/01_fix_xt_qtaguid.patch" \
-        "$DS_BASE_URL/01.fix_kernel_panic_in_xt_qtaguid.patch"
-    wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/02_fix_cgroup_prefix.patch" \
-        "$DS_BASE_URL/02.fix_restore%20cgroup%20file%20prefix%20handling%20.patch"
+echo "[*] Downloading DroidSpaces kernel patches..."
+wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/01_fix_xt_qtaguid.patch" \
+    "$DS_BASE_URL/01.fix_kernel_panic_in_xt_qtaguid.patch"
+wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/02_fix_cgroup_prefix.patch" \
+    "$DS_BASE_URL/02.fix_restore%20cgroup%20file%20prefix%20handling%20.patch"
 
-    cd "$KERNEL_DIR"
+cd "$KERNEL_DIR"
 
-    # Classify the tree state with dry-runs first, then apply, skip, or warn.
-    # -f: never prompt and never auto-swap the patch direction.
-    apply_droidspaces_patch() {
-        local patch_file=$1
-        local name
-        name=$(basename "$patch_file")
+# Classify the tree state with dry-runs first, then apply, skip, or warn.
+# -f: never prompt and never auto-swap the patch direction.
+apply_droidspaces_patch() {
+    local patch_file=$1
+    local name
+    name=$(basename "$patch_file")
 
-        # Reverse dry-run succeeds -> patch is already fully applied
-        if patch -p1 --reverse --dry-run -f < "$patch_file" > /dev/null 2>&1; then
-            echo "[-] Patch already applied, skipping: $name"
-            return 0
-        fi
-
-        # Forward dry-run succeeds -> tree is clean, apply for real
-        if patch -p1 --forward --dry-run -f < "$patch_file" > /dev/null 2>&1; then
-            patch -p1 --forward -f < "$patch_file"
-            echo "[+] Patch applied: $name"
-            return 0
-        fi
-
-        # Target file is missing -> not applicable to this tree, skip by design
-        if patch -p1 --forward --dry-run -f < "$patch_file" 2>&1 | grep -q "can't find file to patch"; then
-            echo "[-] Patch not applicable (target file missing), skipping: $name"
-            return 0
-        fi
-
-        # Otherwise the patch is partially applied or conflicts with the tree
-        echo "[!] WARNING: Patch partially applied or conflicting, skipping: $name"
-        echo "[!] The resulting kernel may miss part of the DroidSpaces fixes."
+    # Reverse dry-run succeeds -> patch is already fully applied
+    if patch -p1 --reverse --dry-run -f < "$patch_file" > /dev/null 2>&1; then
+        echo "[-] Patch already applied, skipping: $name"
         return 0
-    }
+    fi
 
-    # 1) xt_qtaguid panic fix (auto-skipped if net/netfilter/xt_qtaguid.c does not exist)
-    apply_droidspaces_patch "$DS_TMP_DIR/01_fix_xt_qtaguid.patch"
+    # Forward dry-run succeeds -> tree is clean, apply for real
+    if patch -p1 --forward --dry-run -f < "$patch_file" > /dev/null 2>&1; then
+        patch -p1 --forward -f < "$patch_file"
+        echo "[+] Patch applied: $name"
+        return 0
+    fi
 
-    # 2) cgroup file prefix handling fix (required by DroidSpaces)
-    apply_droidspaces_patch "$DS_TMP_DIR/02_fix_cgroup_prefix.patch"
+    # Target file is missing -> not applicable to this tree, skip by design
+    if patch -p1 --forward --dry-run -f < "$patch_file" 2>&1 | grep -q "can't find file to patch"; then
+        echo "[-] Patch not applicable (target file missing), skipping: $name"
+        return 0
+    fi
 
-    # Generate DroidSpaces config fragment for later merging into out/.config
-    DS_CONFIG_FRAG="$DS_TMP_DIR/droidspaces.config"
-    cat > "$DS_CONFIG_FRAG" <<'EOF'
+    # Otherwise the patch is partially applied or conflicts with the tree
+    echo "[!] WARNING: Patch partially applied or conflicting, skipping: $name"
+    echo "[!] The resulting kernel may miss part of the DroidSpaces fixes."
+    return 0
+}
+
+# 1) xt_qtaguid panic fix (auto-skipped if net/netfilter/xt_qtaguid.c does not exist)
+apply_droidspaces_patch "$DS_TMP_DIR/01_fix_xt_qtaguid.patch"
+
+# 2) cgroup file prefix handling fix (required by DroidSpaces)
+apply_droidspaces_patch "$DS_TMP_DIR/02_fix_cgroup_prefix.patch"
+
+# Generate DroidSpaces config fragment for later merging into out/.config
+DS_CONFIG_FRAG="$DS_TMP_DIR/droidspaces.config"
+cat > "$DS_CONFIG_FRAG" <<'EOF'
 # Kernel configurations for full DroidSpaces support
 # Copyright (C) 2026 ravindu644 <droidcasts@protonmail.com>
 
@@ -264,9 +260,8 @@ CONFIG_NETFILTER_NETLINK_LOG=y
 CONFIG_NETFILTER_XT_TARGET_NFLOG=y
 EOF
 
-    echo "[+] DroidSpaces setup finished."
-    echo "==========================================="
-fi
+echo "[+] DroidSpaces setup finished."
+echo "==========================================="
 
 # ==========================================
 # AnyKernel3 Setup
@@ -434,10 +429,8 @@ build_target() {
     fi
 
     # 5. DroidSpaces configurations
-    if [ "$ENABLE_DROIDSPACES" -eq 1 ]; then
-        echo "[*] Merging DroidSpaces configurations..."
-        scripts/kconfig/merge_config.sh -O "${OUT_DIR}/" -m "${OUT_DIR}/.config" "${DS_CONFIG_FRAG}"
-    fi
+    echo "[*] Merging DroidSpaces configurations..."
+    scripts/kconfig/merge_config.sh -O "${OUT_DIR}/" -m "${OUT_DIR}/.config" "${DS_CONFIG_FRAG}"
 
     # We always need to re-evaluate dependencies because BBG is injected unconditionally
     echo "[*] Updating config (make olddefconfig)..."
@@ -478,10 +471,7 @@ build_target() {
         if [ "$ENABLE_KSU" -eq 1 ]; then
             KSU_ZIP_STR="ReSukiSU-SuSFS"
         fi
-        local DS_ZIP_STR=""
-        if [ "$ENABLE_DROIDSPACES" -eq 1 ]; then
-            DS_ZIP_STR="_DroidSpaces"
-        fi
+        local DS_ZIP_STR="_DroidSpaces"
         local GIT_COMMIT_ID=$(git rev-parse --short=8 HEAD 2>/dev/null || echo "unknown")
         local OS_UPPER=$(echo "$OS_TYPE" | tr '[:lower:]' '[:upper:]')
         local ZIP_FILENAME="APTKernel_${OS_UPPER}_${DEVICE_NAME}_${KSU_ZIP_STR}${DS_ZIP_STR}_$(date +'%Y%m%d_%H%M%S')_anykernel3_${GIT_COMMIT_ID}.zip"

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -30,6 +30,7 @@ fi
 ENABLE_KSU=0
 ENABLE_DROIDSPACES=0
 TARGET_OS="both"
+DS_TMP_DIR=""
 
 shift
 # Parse remaining arguments loosely
@@ -41,6 +42,14 @@ for arg in "$@"; do
         droidspaces) ENABLE_DROIDSPACES=1 ;;
     esac
 done
+
+# Remove the DroidSpaces temp dir on exit, whether the build succeeds or fails
+cleanup() {
+    if [ -n "$DS_TMP_DIR" ] && [ -d "$DS_TMP_DIR" ]; then
+        rm -rf "$DS_TMP_DIR"
+    fi
+}
+trap cleanup EXIT
 
 # ==========================================
 # Configuration & Environment
@@ -109,22 +118,43 @@ if [ "$ENABLE_DROIDSPACES" -eq 1 ]; then
     DS_BASE_URL="https://raw.githubusercontent.com/ravindu644/Droidspaces-OSS/main/Documentation/resources/kernel-patches/non-GKI"
 
     echo "[*] Downloading DroidSpaces kernel patches..."
-    wget -q -O "$DS_TMP_DIR/01_fix_xt_qtaguid.patch" \
+    wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/01_fix_xt_qtaguid.patch" \
         "$DS_BASE_URL/01.fix_kernel_panic_in_xt_qtaguid.patch"
-    wget -q -O "$DS_TMP_DIR/02_fix_cgroup_prefix.patch" \
+    wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/02_fix_cgroup_prefix.patch" \
         "$DS_BASE_URL/02.fix_restore%20cgroup%20file%20prefix%20handling%20.patch"
 
     cd "$KERNEL_DIR"
 
-    # Dry-run first: skip cleanly when already applied or not applicable
+    # Classify the tree state with dry-runs first, then apply, skip, or warn.
+    # -f: never prompt and never auto-swap the patch direction.
     apply_droidspaces_patch() {
         local patch_file=$1
-        if patch -p1 --forward --dry-run < "$patch_file" > /dev/null 2>&1; then
-            patch -p1 --forward < "$patch_file"
-            echo "[+] Patch applied: $(basename "$patch_file")"
-        else
-            echo "[-] Patch skipped (already applied or not applicable): $(basename "$patch_file")"
+        local name
+        name=$(basename "$patch_file")
+
+        # Reverse dry-run succeeds -> patch is already fully applied
+        if patch -p1 --reverse --dry-run -f < "$patch_file" > /dev/null 2>&1; then
+            echo "[-] Patch already applied, skipping: $name"
+            return 0
         fi
+
+        # Forward dry-run succeeds -> tree is clean, apply for real
+        if patch -p1 --forward --dry-run -f < "$patch_file" > /dev/null 2>&1; then
+            patch -p1 --forward -f < "$patch_file"
+            echo "[+] Patch applied: $name"
+            return 0
+        fi
+
+        # Target file is missing -> not applicable to this tree, skip by design
+        if patch -p1 --forward --dry-run -f < "$patch_file" 2>&1 | grep -q "can't find file to patch"; then
+            echo "[-] Patch not applicable (target file missing), skipping: $name"
+            return 0
+        fi
+
+        # Otherwise the patch is partially applied or conflicts with the tree
+        echo "[!] WARNING: Patch partially applied or conflicting, skipping: $name"
+        echo "[!] The resulting kernel may miss part of the DroidSpaces fixes."
+        return 0
     }
 
     # 1) xt_qtaguid panic fix (auto-skipped if net/netfilter/xt_qtaguid.c does not exist)
@@ -483,10 +513,5 @@ fi
 echo "==========================================="
 echo "[*] ccache stats:"
 ccache -s
-
-# Cleanup DroidSpaces temp directory
-if [ -n "$DS_TMP_DIR" ] && [ -d "$DS_TMP_DIR" ]; then
-    rm -rf "$DS_TMP_DIR"
-fi
 
 echo "[+] All requested builds completed!"

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -114,10 +114,18 @@ DS_TMP_DIR=$(mktemp -d)
 DS_BASE_URL="https://raw.githubusercontent.com/ravindu644/Droidspaces-OSS/main/Documentation/resources/kernel-patches/non-GKI"
 
 echo "[*] Downloading DroidSpaces kernel patches..."
-wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/01_fix_xt_qtaguid.patch" \
-    "$DS_BASE_URL/01.fix_kernel_panic_in_xt_qtaguid.patch"
-wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/02_fix_cgroup_prefix.patch" \
-    "$DS_BASE_URL/02.fix_restore%20cgroup%20file%20prefix%20handling%20.patch"
+if ! wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/01_fix_xt_qtaguid.patch" \
+    "$DS_BASE_URL/01.fix_kernel_panic_in_xt_qtaguid.patch"; then
+    echo "[!] Error: Failed to download DroidSpaces patch 01 (xt_qtaguid fix)."
+    echo "[!] Check your network connection and try again."
+    exit 1
+fi
+if ! wget -q --timeout=30 --tries=3 -O "$DS_TMP_DIR/02_fix_cgroup_prefix.patch" \
+    "$DS_BASE_URL/02.fix_restore%20cgroup%20file%20prefix%20handling%20.patch"; then
+    echo "[!] Error: Failed to download DroidSpaces patch 02 (cgroup prefix fix)."
+    echo "[!] Check your network connection and try again."
+    exit 1
+fi
 
 cd "$KERNEL_DIR"
 


### PR DESCRIPTION
## Summary

Add DroidSpaces support to the kernel build system, wire it into both GitHub
Actions workflows, and finally make it enabled by default for all builds from
the `Build All Devices Kernel (Matrix Parallel + Release)` workflow, with
hardened patch handling and corrected documentation along the way.

## Changes

**`build_kernel.sh`**
- New `droidspaces` build argument to enable DroidSpaces support on demand,
  without touching the tree when not needed
- When enabled, fetch the non-GKI kernel patches from the upstream
  Droidspaces-OSS repository at build time and apply them idempotently
- The patches fix a potential kernel panic in `xt_qtaguid` on inactive
  interfaces and restore the cgroup file prefix handling required by
  DroidSpaces
- Merge the DroidSpaces config fragment (namespaces, cgroups, seccomp,
  netfilter, veth, bridge) into the kernel config with
  `scripts/kconfig/merge_config.sh` before `olddefconfig`
- Append a `DroidSpaces` tag to the flashable ZIP filename so builds can
  be told apart
- Hardened patch handling:
  - `DS_TMP_DIR` is initialized at startup and removed via an `EXIT` trap,
    so the temp directory is cleaned up even when the build fails midway,
    and a pre-existing `DS_TMP_DIR` env var can no longer leak into the
    cleanup path
  - Patch state is classified with `-f` dry-runs (reverse first, then
    forward): fully applied patches are skipped idempotently, patches whose
    target file is missing are skipped by design, and partially applied or
    conflicting patches now emit a clear warning instead of being silently
    skipped (`-f` prevents patch from prompting or auto-swapping direction)
  - Patch downloads use `--timeout=30 --tries=3` so a stalled network no
    longer blocks the build indefinitely

**`.github/workflows/build.yml` / `.github/workflows/build_all.yml`**
- Add the DroidSpaces build option to the workflows and pass it to
  `build_kernel.sh`
- `build_all.yml` now enables DroidSpaces unconditionally: the optional
  `droidspaces` `workflow_dispatch` input is removed and the flag is always
  passed, so every matrix build ships with DroidSpaces support
- Update the release notes template to reflect the DroidSpaces ZIP tag and
  how to build without DroidSpaces

**`README.md`**
- Add a note (Chinese and English) in the Quick Build section stating that
  all builds from the all-devices workflow come with DroidSpaces enabled
- Since forks also enable DroidSpaces in the all-devices workflow, point
  users who don't want it to the single-device `Build Kernel` workflow
  (DroidSpaces option off by default), or to adjusting the workflow
  themselves

## Testing

Tested and built in https://github.com/bcggxx/android_kernel_xiaomi_sm8250/actions/runs/34122948546

Note: all KernelSU-enabled builds failed because SuSFS has not been updated yet (unrelated to this PR).

## Commits

- `acc30e45` build: add DroidSpaces build option
- `8ea975ae` ci: add DroidSpaces build option to workflows
- `9f27a1ef` ci: always enable DroidSpaces in all-devices build workflow
- `cdc99da2` docs: note DroidSpaces is always enabled in all-devices CI builds
- `3bffd814` build: harden DroidSpaces patch handling in build_kernel.sh
- `8c62fc58` docs: clarify how to build kernels without DroidSpaces

## Impact

- `4 files changed, 204 insertions(+), 3 deletions(-)` — build script,
  workflows and docs only, no kernel source changes
- Kernel with DroidSpaces disabled is completely untouched; the patch and
  config merge only run when the option is enabled
- Single-device `Build Kernel` workflow and manual builds are unaffected
